### PR TITLE
Fix projectUrl in project NuSpec

### DIFF
--- a/src/Bass/ManagedBass.nuspec
+++ b/src/Bass/ManagedBass.nuspec
@@ -6,7 +6,7 @@
         <title>ManagedBass</title>
         <authors>MathewSachin</authors>
         <licenseUrl>https://raw.githubusercontent.com/ManagedBass/Home/master/LICENSE.md</licenseUrl>
-        <projectUrl>https://github.com/ManagedBass/ManagedBass.PInvoke/</projectUrl>
+        <projectUrl>https://github.com/ManagedBass/ManagedBass/</projectUrl>
         <iconUrl>https://github.com/ManagedBass.png</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>.Net Wrapper for un4seen Audio Library.</description>


### PR DESCRIPTION
I noticed that the project url for Nuget is the old one, this is the update :)