### PR TITLE
Fix incorrect return of ChannelGetLevelLeft/ChannelGetLevelRight.

### DIFF
--- a/src/Bass/Shared/Bass/PInvoke/Channels.cs
+++ b/src/Bass/Shared/Bass/PInvoke/Channels.cs
@@ -634,7 +634,7 @@ namespace ManagedBass
         /// <returns>If the attribute (or any) is sliding, then <see langword="true" /> is returned, else <see langword="false" /> is returned.</returns>
         [DllImport(DllName, EntryPoint = "BASS_ChannelIsSliding")]
         public static extern bool ChannelIsSliding(int Handle, ChannelAttribute Attribute);
-        
+
         /// <summary>
         /// Slides a channel's attribute from its current value to a new value.
         /// </summary>
@@ -696,12 +696,12 @@ namespace ManagedBass
         /// <summary>
         /// Gets the Level of the Left Channel.
         /// </summary>
-        public static int ChannelGetLevelLeft(int Handle) => ChannelGetLevel(Handle).LoWord();
+        public static ushort ChannelGetLevelLeft(int Handle) => (ushort)ChannelGetLevel(Handle).LoWord();
 
         /// <summary>
         /// Gets the Level of the Right Channel.
         /// </summary>
-        public static int ChannelGetLevelRight(int Handle) => ChannelGetLevel(Handle).HiWord();
+        public static ushort ChannelGetLevelRight(int Handle) => (ushort)ChannelGetLevel(Handle).HiWord();
 
         /// <summary>
         /// Retrieves the level (peak amplitude) of a sample, stream, MOD music or recording channel.


### PR DESCRIPTION
[ChannelGetLevel](http://www.bass.radio42.com/help/html/5f031dfc-effe-35a9-c60d-21856e15a59e.htm) is explicitly defined by BASS to return a ushort range for each channel.

BitHelper.cs is unchanged with this to preserve consistency with the BASS.NET.Utils (although this is the only function that uses LoWord/HiWord right now). Let me know if you'd prefer that was changed also.