### PR TITLE
Fix incorrect bit shifts and incorrect ChannelGetLevelLeft/ChannelGetLevelRight returns

### DIFF
--- a/src/Bass/Shared/Bass/PInvoke/Channels.cs
+++ b/src/Bass/Shared/Bass/PInvoke/Channels.cs
@@ -696,12 +696,28 @@ namespace ManagedBass
         /// <summary>
         /// Gets the Level of the Left Channel.
         /// </summary>
-        public static int ChannelGetLevelLeft(int Handle) => ChannelGetLevel(Handle).LoWord();
+        public static int ChannelGetLevelLeft(int Handle)
+        {
+            int value = ChannelGetLevel(Handle);
+
+            if (value == -1)
+                return -1;
+
+            return value.LoWord();
+        }
 
         /// <summary>
         /// Gets the Level of the Right Channel.
         /// </summary>
-        public static int ChannelGetLevelRight(int Handle) => ChannelGetLevel(Handle).HiWord();
+        public static int ChannelGetLevelRight(int Handle)
+        {
+            int value = ChannelGetLevel(Handle);
+
+            if (value == -1)
+                return -1;
+
+            return value.HiWord();
+        }
 
         /// <summary>
         /// Retrieves the level (peak amplitude) of a sample, stream, MOD music or recording channel.

--- a/src/Bass/Shared/BitHelper.cs
+++ b/src/Bass/Shared/BitHelper.cs
@@ -10,7 +10,7 @@ namespace ManagedBass
         /// <summary>
         /// The return value is the high-order double word of the specified value.
         /// </summary>
-        public static long HiDword(this long DWord) => DWord >> 32;
+        public static long HiDword(this long DWord) => (long)((ulong)DWord >> 32);
 
         /// <summary>
         /// The return value is the low-order word of the specified value.
@@ -20,7 +20,7 @@ namespace ManagedBass
         /// <summary>
         /// The return value is the high-order word of the specified value.
         /// </summary>
-        public static int HiWord(this int DWord) => DWord >> 16;
+        public static int HiWord(this int DWord) => (int)((uint)DWord >> 16);
 
         /// <summary>
         /// The return value is the low-order word of the specified value.


### PR DESCRIPTION
"If the first operand is an int or long, the right-shift is an arithmetic shift": https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/right-shift-operator