### PR TITLE
Fix unsafe PropertyChanged invocation

### DIFF
--- a/src/Bass/Shared/MediaPlayer.cs
+++ b/src/Bass/Shared/MediaPlayer.cs
@@ -397,11 +397,7 @@ namespace ManagedBass
         /// </summary>
         protected virtual void OnPropertyChanged([CallerMemberName] string PropertyName = null)
         {
-            var propertyChanged = PropertyChanged;
-            if (propertyChanged == null)
-                return;
-
-            Action f = () => propertyChanged.Invoke(this, new PropertyChangedEventArgs(PropertyName));
+            Action f = () => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(PropertyName));
 
             if (_syncContext == null)
                 f();

--- a/src/Bass/Shared/MediaPlayer.cs
+++ b/src/Bass/Shared/MediaPlayer.cs
@@ -397,10 +397,11 @@ namespace ManagedBass
         /// </summary>
         protected virtual void OnPropertyChanged([CallerMemberName] string PropertyName = null)
         {
-            if (PropertyChanged == null)
+            var propertyChanged = PropertyChanged;
+            if (propertyChanged == null)
                 return;
 
-            Action f = () => PropertyChanged.Invoke(this, new PropertyChangedEventArgs(PropertyName));
+            Action f = () => propertyChanged.Invoke(this, new PropertyChangedEventArgs(PropertyName));
 
             if (_syncContext == null)
                 f();


### PR DESCRIPTION
Theoretically `PropertyChanged` can be unsubscribed from another thread after the null check.