### PR TITLE
Added support for BassWasapi 2.4.3

### DIFF
--- a/src/AddOns/BassWasapi/BassWasapi.cs
+++ b/src/AddOns/BassWasapi/BassWasapi.cs
@@ -32,7 +32,23 @@ namespace ManagedBass.Wasapi
         /// Identifier for Default Loopback Device.
         /// </summary>
         public const int DefaultLoopbackDevice = -3;
-        
+
+        /// <summary>
+        /// Instead of BASSWASAPI pulling data from a WASAPIPROC function, data is pushed to
+        /// BASSWASAPI via BASS_WASAPI_PutData. This cannot be used with input devices or the
+        /// BASS_WASAPI_EVENT flag. 
+        /// </summary>
+        public static readonly IntPtr WasapiProc_Push = new IntPtr(0);
+
+        /// <summary>
+        /// Feed data to/from a BASS channel, specified in the user parameter.
+        /// It must be a decoding channel (using BASS_STREAM_DECODE) for an output device,
+        /// or a "push" or "dummy" stream (using STREAMPROC_PUSH or STREAMPROC_DUMMY) for
+        /// an input device. The freq and chans parameters are ignored and the sample format
+        /// of the BASS channel is used instead, but it must be floating-point (BASS_SAMPLE_FLOAT).  
+        /// </summary>
+        public static readonly IntPtr WasapiProc_Bass = new IntPtr(-1);
+
         #region CPU
         [DllImport(DllName)]
         static extern float BASS_WASAPI_GetCPU();
@@ -509,6 +525,85 @@ namespace ManagedBass.Wasapi
                                        float Period = 0,
                                        WasapiProcedure Procedure = null,
                                        IntPtr User = default(IntPtr));
+
+        /// <summary>
+        /// Initializes a Wasapi device/driver (endpoint).
+        /// </summary>
+        /// <param name="Device">The device to use... 0 = first device, -1 = default output device, -2 = default input device. <see cref="GetDeviceInfo(int,out WasapiDeviceInfo)" /> can be used to enumerate the available devices.</param>
+        /// <param name="Frequency">The sample rate to use... 0 = "mix format" sample rate.</param>
+        /// <param name="Channels">The number of channels to use... 0 = "mix format" channels, 1 = mono, 2 = stereo, etc.</param>
+        /// <param name="Flags">A combination of <see cref="WasapiInitFlags"/>.</param>
+        /// <param name="Buffer">
+        /// The length of the device's buffer in seconds.
+        /// This is a minimum and the driver may choose to use a larger buffer;
+        /// <see cref="Info" /> can be used to confirm what the buffer size is.
+        /// For an output device, the buffer size determines the latency.
+        /// </param>
+        /// <param name="Period">
+        /// The interval (in seconds) between callback function calls... 0 = use default.
+        /// If the specified period is below the minimum update period, it will automatically be raised to that.
+        /// <para>
+        /// The update period specifies the time between <see cref="WasapiProcedure" /> calls.
+        /// The <see cref="WasapiDeviceInfo" /> (see <see cref="GetDeviceInfo(int,out WasapiDeviceInfo)" />) "minperiod" and "defperiod" values are actually minimum/default update periods.
+        /// </para>
+        /// </param>
+        /// <param name="Procedure">
+        /// The user defined function to process the channel.
+        /// Use <see langword="null" /> to create a Wasapi "push" device (to which you can feed sample data via <see cref="PutData(IntPtr,int)" />).
+        /// </param>
+        /// <param name="User">User instance data to pass to the callback function.</param>
+        /// <returns>If the device was successfully initialized, <see langword="true" /> is returned, else <see langword="false" /> is returned. Use <see cref="Bass.LastError" /> to get the error code.</returns>
+        /// <remarks>
+        /// <para>
+        /// For convenience, devices are always initialized to use their highest sample resolution and that is then converted to 32-bit floating-point, so that <see cref="WasapiProcedure"/> callback functions and the <see cref="PutData(IntPtr,int)" /> and <see cref="GetData(IntPtr,int)" /> functions are always dealing with the same sample format.
+        /// The device's sample format can be obtained via <see cref="Info" />.
+        /// </para>
+        /// <para>
+        /// WASAPI does not support arbitrary sample formats, like DirectSound does.
+        /// In particular, only the "mix format" (available from <see cref="GetDeviceInfo(int,out WasapiDeviceInfo)" />) is generally supported in shared mode.
+        /// <see cref="CheckFormat" /> can be used to check whether a particular sample format is supported.
+        /// The BASSmix add-on can be used to play (or record) in otherwise unsupported sample formats, as well as playing multiple sources.
+        /// </para>
+        /// <para>The initialized device will not begin processing data until <see cref="Start" /> is called.</para>
+        /// <para>
+        /// Simultaneously using multiple devices is supported in the BASS API via a context switching system; instead of there being an extra "device" parameter in the function calls, the device to be used is set prior to calling the functions.
+        /// <see cref="CurrentDevice" /> is used to switch the current device.
+        /// When successful, <see cref="Init" /> automatically sets the current thread's device to the one that was just initialized.
+        /// </para>
+        /// <para>When using the default output or input device, <see cref="CurrentDevice" /> can be used to find out which device it was mapped to.</para>
+        /// <para>In SHARED mode you must initialize the device with the current WASAPI mixer sample rate and number of channels (see the <see cref="WasapiDeviceInfo" /> "mixfreq" and "mixchans" properties).</para>
+        /// <para>In EXCLUSIVE mode you might use any sample rate and number of channels which are supported by the device/driver.</para>
+        /// <para>This function must be successfully called before any input or output can be performed.</para>
+        /// <para>
+        /// In EXCLUSIVE mode, the "period" value will affect what's an acceptable "buffer" value (it appears that the buffer must be at least 4x the period).
+        /// In SHARED mode, it's the other way round, the "period" will be reduced to fit the "buffer" if necessary (with a minimum of the "defperiod" value).
+        /// The system will limit them to an acceptable range, so for example, you could use a very small value (eg. 0.0001) for both, to get the minimum possible latency.
+        /// </para>
+        /// <para>
+        /// Note: When initializing an input (capture or loopback) device, it might be the case, that the device is automatically muted once initialized.
+        /// You can use the <see cref="GetMute" />/<see cref="SetMute" /> methods to check and probably toggle this.
+        /// </para>
+        /// </remarks>
+        /// <exception cref="Errors.Wasapi">WASAPI is not available.</exception>
+        /// <exception cref="Errors.Device">The <paramref name="Device" /> number specified is invalid.</exception>
+        /// <exception cref="Errors.Already">A device has already been initialized. You must call <see cref="Free" /> before you can initialize again.</exception>
+        /// <exception cref="Errors.Parameter">An illegal parameter was specified (a <see cref="WasapiProcedure"/> must be provided for an input device).</exception>
+        /// <exception cref="Errors.Driver">The driver could not be initialized.</exception>
+        /// <exception cref="Errors.SampleFormat">The specified format is not supported by the device. If the <see cref="WasapiInitFlags.AutoFormat"/> flag was specified, no other format could be found either.</exception>
+        /// <exception cref="Errors.Init">The <see cref="Bass.NoSoundDevice"/> has not been initialized.</exception>
+        /// <exception cref="Errors.Busy">The device is busy (eg. in "exclusive" use by another process).</exception>
+        /// <exception cref="Errors.Unknown">Some other mystery error.</exception>
+        [DllImport(DllName, EntryPoint = "BASS_WASAPI_Init")]
+        public static extern bool InitEx(int Device,
+                                        int Frequency = 0,
+                                        int Channels = 0,
+                                        WasapiInitFlags Flags = WasapiInitFlags.Shared,
+                                        float Buffer = 0,
+                                        float Period = 0,
+                                        IntPtr Procedure = default(IntPtr),
+                                        IntPtr User = default(IntPtr));
+
+       
 
         #region IsStarted
         [DllImport(DllName)]

--- a/src/AddOns/BassWasapi/Enumerations/WasapiInitFlags.cs
+++ b/src/AddOns/BassWasapi/Enumerations/WasapiInitFlags.cs
@@ -48,6 +48,86 @@ namespace ManagedBass.Wasapi
         /// Apply dither (TPDF) when converting floating-point sample data to the device's format.
         /// This flag only has effect on exclusive mode output.
         /// </summary>
-        Dither = 0x40
+        Dither = 0x40,
+
+        /// <summary>
+        /// Request raw mode, which bypasses any sound enhancements that have been enabled on the device. This is only available on Windows 8.1 and above. 
+        /// </summary>
+        Raw = 0x80,
+
+        /// <summary>
+        /// Call the callback function asynchronously. This only applies to event-driven exclusive mode output and is otherwise ignored. When enabled,
+        /// a buffer is filled asynchronously in advance. This reduces the chances of underruns but also increases latency by up to one buffer length. If an underrun does occur, a silent buffer (rather than nothing) is still sent to the device, which can prevent sound glitches on some devices following an underrun. 
+        /// </summary>
+        Async = 0x100,
+
+
+        // --- WASAPI Device Category Flags ---
+        // One of the following can also be used to set the audio category on Windows 8 and above (otherwise ignored).
+
+        /// <summary>
+        /// A mask to isolate the category flags. 
+        /// </summary>
+        CategoryMask = 0xf000,
+
+        /// <summary>
+        /// Other audio stream. 
+        /// </summary>
+        CategoryOther = 0x0000,
+
+        /// <summary>
+        /// Unknown flag.
+        /// </summary>
+        CategoryForegroundMediaOnly	=0x1000,
+
+        /// <summary>
+        /// Unknown flag.
+        /// </summary>
+        CategoryBackgroundMediaCapable=0x2000,
+
+        /// <summary>
+        /// Real-time communications, such as VOIP or chat. 
+        /// </summary>
+        CategoryCommunications = 0x3000,
+
+        /// <summary>
+        /// Alert sounds. For output devices only. 
+        /// </summary>
+        CategoryAlerts = 0x4000,
+
+        /// <summary>
+        /// Sound effects. For output devices only. 
+        /// </summary>
+        CategorySoundEffects = 0x5000,
+
+        /// <summary>
+        /// Game sound effects. For output devices only. 
+        /// </summary>
+        CategoryGameEffects = 0x6000,
+
+        /// <summary>
+        /// Background audio for games. For output devices only. 
+        /// </summary>
+        CategoryGameMedia = 0x7000,
+
+        /// <summary>
+        /// Game chat audio. Similar to COMMUNICATIONS except that this will not attenuate other streams. For output devices only. 
+        /// </summary>
+        CategoryGameChat = 0x8000,
+
+        /// <summary>
+        /// Speech. 
+        /// </summary>
+        CategorySpeech = 0x9000,
+
+        /// <summary>
+        /// Stream that includes audio with dialog. For output devices only. 
+        /// </summary>
+        CategoryMovie = 0xa000,
+
+        /// <summary>
+        /// Stream that includes audio without dialog. For output devices only. 
+        /// </summary>
+        CategoryMedia = 0xb000
     }
 }


### PR DESCRIPTION
Implemented support for the following new features:

2.4.3 - 27/3/2020 (From BassWasapi Documentation)
-----------------
* BASS channel support
	WASAPIPROC_BASS (BASS_WASAPI_Init option)
* Asynchronous output buffering
	BASS_WASAPI_ASYNC (BASS_WASAPI_Init option)
* Constant defined for push output option
	WASAPIPROC_PUSH (BASS_WASAPI_Init option)
* Raw mode support
	BASS_WASAPI_RAW (BASS_WASAPI_Init flag)
* Category support
	BASS_WASAPI_CATEGORY_xxx (BASS_WASAPI_Init flags)
* Any BASS device (not only "No Sound") can be used for buffering
	BASS_WASAPI_BUFFER (BASS_WASAPI_Init flag)

NOTE: To support the new WasapiProc_Push and WasapiProc_Bass features, it was necessary to create a new Init method, with the name InitEx() that supports the passing of the WasapiProc as an IntPtr rather than a delegate. An overload of the Init() method would have introduced a breaking change due to the ambiguity of the overloaded method.

The WasapiProc_Bass and WasapiProc_Push are implemted at readonly static IntPtrs on the BassWasapi class, in lieu of the constants defined in the BassWasapi.h header.

Example usage:

```c#
BassWasapi.InitEx(-1, 
   Procedure: BassWasapi.WasapiProc_Bass, 
   Flags: WasapiInitFlags.Exclusive, 
   User: new IntPtr(channelHandle));
```