### PR TITLE
Added support for BassMix 2.4.10

### DIFF
--- a/src/AddOns/BassMix/MixEnvelope.cs
+++ b/src/AddOns/BassMix/MixEnvelope.cs
@@ -32,6 +32,11 @@ namespace ManagedBass.Mix
         /// <summary>
         /// Loop the envelope (flag).
         /// </summary>
-        Loop = 0x10000
+        Loop = 0x10000,
+
+        /// <summary>
+        /// Remove the source from the mixer at the end of the envelope. This is a flag and can be used in combination with any of the above.
+        /// </summary>
+        Remove = 0x20000
     }
 }

--- a/src/Bass/Shared/Bass/Enumerations/BassFlags.cs
+++ b/src/Bass/Shared/Bass/Enumerations/BassFlags.cs
@@ -358,6 +358,12 @@ namespace ManagedBass
         #endregion
 
         #region BassMix
+
+        /// <summary>
+        /// Only relevant for StreamAddChannelEx(): Start is an absolute position in the mixer output rather than relative to the mixer's current position. If the position has already passed then the source will start immediately.
+        /// </summary>
+        MixerChanAbsolute = 0x1000,
+
         /// <summary>
         /// BASSmix add-on: only read buffered data.
         /// </summary>
@@ -381,12 +387,24 @@ namespace ManagedBass
         /// <summary>
         /// BASSmix add-on: Buffer source data for BassMix.ChannelGetData(int,IntPtr,int) and BassMix.ChannelGetLevel(int).
         /// </summary>
-        MixerBuffer = 0x2000,
+        MixerChanBuffer = 0x2000,
+
+        /// <summary>
+        /// BASSmix add-on: Buffer source data for BassMix.ChannelGetData(int,IntPtr,int) and BassMix.ChannelGetLevel(int).
+        /// </summary>
+        [Obsolete("Renamed to MixerChanBuffer for clarity.")]
+        MixerBuffer = MixerChanBuffer,
 
         /// <summary>
         /// BASSmix add-on: Limit mixer processing to the amount available from this source.
         /// </summary>
-        MixerLimit = 0x4000,
+        MixerChanLimit = 0x4000,
+
+        /// <summary>
+        /// BASSmix add-on: Limit mixer processing to the amount available from this source.
+        /// </summary>
+        [Obsolete("Renamed to MixerChanLimit for clarity.")]
+        MixerLimit = MixerChanLimit,
 
         /// <summary>
         /// BASSmix add-on: end the stream when there are no sources
@@ -396,7 +414,13 @@ namespace ManagedBass
         /// <summary>
         /// BASSmix add-on: Matrix mixing
         /// </summary>
-        MixerMatrix = 0x10000,
+        MixerChanMatrix = 0x10000,
+
+        /// <summary>
+        /// BASSmix add-on: Matrix mixing
+        /// </summary>
+        [Obsolete("Renamed to MixerChanMatrix for clarity.")]
+        MixerMatrix = MixerChanMatrix,
 
         /// <summary>
         /// BASSmix add-on: don't stall when there are no sources
@@ -406,17 +430,35 @@ namespace ManagedBass
         /// <summary>
         /// BASSmix add-on: don't process the source
         /// </summary>
-        MixerPause = 0x20000,
+        MixerChanPause = 0x20000,
+
+        /// <summary>
+        /// BASSmix add-on: don't process the source
+        /// </summary>
+        [Obsolete("Renamed to MixerChanPause for clarity.")]
+        MixerPause = MixerChanPause,
 
         /// <summary>
         /// BASSmix add-on: downmix to stereo (or mono if mixer is mono)
         /// </summary>
-        MixerDownMix = 0x400000,
+        MixerChanDownMix = 0x400000,
+
+        /// <summary>
+        /// BASSmix add-on: downmix to stereo (or mono if mixer is mono)
+        /// </summary>
+        [Obsolete("Renamed to MixerChanDownMix for clarity.")]
+        MixerDownMix = MixerChanDownMix,
 
         /// <summary>
         /// BASSmix add-on: don't ramp-in the start
         /// </summary>
-        MixerNoRampin = 0x800000,
+        MixerChanNoRampin = 0x800000,
+
+        /// <summary>
+        /// BASSmix add-on: don't ramp-in the start
+        /// </summary>
+        [Obsolete("Renamed to MixerChanNoRampin for clarity.")]
+        MixerNoRampin = MixerChanNoRampin,
         #endregion
 
         #region Recording

--- a/src/Bass/Shared/Bass/Enumerations/LevelRetrievalFlags.cs
+++ b/src/Bass/Shared/Bass/Enumerations/LevelRetrievalFlags.cs
@@ -26,6 +26,11 @@ namespace ManagedBass
         /// <summary>
         /// Optional Flag: If set it returns RMS levels instead of peak leavels
         /// </summary>
-        RMS = 0x4
+        RMS = 0x4,
+
+        /// <summary>
+        /// Apply the current <see cref="ChannelAttribute.Volume"/> and <see cref="ChannelAttribute.Pan"/> values to the level reading. 
+        /// </summary>
+        VolPan = 0x8
     }
 }

--- a/src/Bass/Shared/Bass/Enumerations/PositionFlags.cs
+++ b/src/Bass/Shared/Bass/Enumerations/PositionFlags.cs
@@ -78,6 +78,12 @@ namespace ManagedBass
         Inexact = 0x8000000,
 
         /// <summary>
+        /// Flag: The requested position is relative to the current position. pos is treated as signed in this case and can be negative.
+        /// Unless the <see cref="PositionFlags.MixerReset"/> flag is also used, this is relative to the current decoding/processing position, which will be ahead of the currently heard position if the mixer output is buffered. 
+        /// </summary>
+        Relative = 0x4000000,
+
+        /// <summary>
         /// Get the decoding (not playing) position.
         /// </summary>
         Decode = 0x10000000,


### PR DESCRIPTION
Added support for BassMix 2.4.10. From Un4Seen's release notes:

```
2.4.10 - 20/3/2020
------------------
* Mixer source flags renamed/duplicated to distinguish from mixer flags
	BASS_MIXER_BUFFER -> BASS_MIXER_CHAN_BUFFER
	BASS_MIXER_LIMIT -> BASS_MIXER_CHAN_LIMIT
	BASS_MIXER_MATRIX -> BASS_MIXER_CHAN_MATRIX
	BASS_MIXER_PAUSE -> BASS_MIXER_CHAN_PAUSE
	BASS_MIXER_DOWNMIX -> BASS_MIXER_CHAN_DOWNMIX
	BASS_MIXER_NORAMPIN -> BASS_MIXER_CHAN_NORAMPIN
* Absolute source start position option
	BASS_MIXER_CHAN_ABSOLUTE (BASS_Mixer_StreamAddChannelEx flag)
* Improved gapless joins with sources that don't end/begin close to a 0 sample
	BASS_Mixer_StreamAddChannel/Ex
* 7th and 8th channels are included in a downmix
	BASS_MIXER_CHAN_DOWNMIX (BASS_Mixer_StreamAddChannel/Ex flag)
* Asynchronous source auto-freeing
	BASS_STREAM_AUTOFREE (BASS_Mixer_StreamAddChannel/Ex flag)
	BASS_Mixer_ChannelRemove
* Source removal at the end of an envelope
	BASS_MIXER_ENV_REMOVE (BASS_Mixer_ChannelSetEnvelope flag)
* Support for relative seeking
	BASS_POS_RELATIVE (BASS_Mixer_ChannelSetPosition flag)
* Volume & panning attribute affected level retrieval
	BASS_LEVEL_VOLPAN (BASS_Mixer_ChannelGetLevelEx flag)
* Data/level retrieval dips into played data when not enough unplayed data
	BASS_Mixer_ChannelGetData
	BASS_Mixer_ChannelGetLevel/Ex
* Support for splitting/cloning dummy streams
	BASS_Split_StreamCreate
```
Most of these updates are internal to the BassMix.dll, so this PR is mostly the addition of enum values to support the new features.