### PR TITLE
#78 - Fix crash related to over reading ID3v2 Data, invalid length in frame header.

### DIFF
--- a/src/Bass/Shared/Tags/Objects/ID3v2/ID3v2Tag.cs
+++ b/src/Bass/Shared/Tags/Objects/ID3v2/ID3v2Tag.cs
@@ -74,6 +74,11 @@ namespace ManagedBass
                 if (frameIdLen == 4)
                     ReadUInt(2);
 
+                //Issue 78 Fix: Dbond (2020-07-16)
+                //add saftey check to make sure we can't read past the overall header length
+                //protecting against an invalid frame value.
+                frameLength = Math.Min(frameLength, Length - 10);  //header space left is length - header size.. (10 bytes)
+
                 var added = AddFrame(frameId, frameLength);
 
                 // if don't read this frame, we must go forward to read next frame


### PR DESCRIPTION
Added a safety check around invalid id3v2 frame header lengths.. 