### PR TITLE
Fix several bugs with undocumented feature of Bass.PluginLoad()

### DIFF
--- a/src/Bass/Shared/Bass/PInvoke/Plugin.cs
+++ b/src/Bass/Shared/Bass/PInvoke/Plugin.cs
@@ -68,11 +68,25 @@ namespace ManagedBass
 
             var dir = Path.GetDirectoryName(FilePath);
             var fileName = Path.GetFileName(FilePath);
-            
+
             // Try for Windows, Linux/Android and OSX Libraries respectively.
-            return new[] { $"{dir}{fileName}.dll", $"{dir}lib{fileName}.so", $"{dir}lib{fileName}.dylib" }
-                           .Select(PluginLoad)
-                           .FirstOrDefault(HLib => HLib != 0);
+            string[] paths = new[] {
+                Path.Combine(dir, $"{fileName}.dll"),
+                Path.Combine(dir, $"lib{fileName}.so"),
+                Path.Combine(dir, $"lib{fileName}.dylib")
+            };
+
+            foreach (string path in paths)
+            {
+                // Check if the file exists before trying to load plugin otherwise Bass.LastError can be overwritten by multiple calls.
+                if (File.Exists(path))
+                {
+                    return BASS_PluginLoad(path);
+                }
+            }
+
+            // Fall back to just returning the result of BASS_PluginLoad so Bass.LastError is set correctly
+            return BASS_PluginLoad(FilePath);
 #endif
         }
         #endregion

--- a/src/Bass/Shared/Bass/PInvoke/Plugin.cs
+++ b/src/Bass/Shared/Bass/PInvoke/Plugin.cs
@@ -81,7 +81,14 @@ namespace ManagedBass
                 // Check if the file exists before trying to load plugin otherwise Bass.LastError can be overwritten by multiple calls.
                 if (File.Exists(path))
                 {
-                    return BASS_PluginLoad(path);
+                    // Only return if we have a valid handle. If we don't keep trying the other files.
+                    var rtnVal = BASS_PluginLoad(path);
+
+                    // Errors.Already means the plugin is already loaded and we have found the proper plugin, we should return in this case
+                    if (rtnVal != 0 || Bass.LastError == Errors.Already)
+                    {
+                        return rtnVal;
+                    }
                 }
             }
 


### PR DESCRIPTION
So Bass.PluginLoad has an undocumented feature here where if you pass in the folder path + base name of the plugin it will add the file extension and prefixes for each platform and try each to see if any will load a valid plugin but i have found several issues with this:

The first bug here is with path handling. The code splits the directory name from the file name then merges them together but does not put a file separator between the two.

The second bug is with the state that it leaves Bass.LastError in after trying to load the plugin. If the plugin fails for any reason such as Errors.FileFormat, or Errors.Already that will get overwritten by later calls for the different platforms and the user will be unable to see why the plugin actually failed to load.