### PR TITLE
Fix ManagedBass assembly would fail to load when using the AddOns

### DIFF
--- a/src/Bass/Desktop/Desktop.csproj
+++ b/src/Bass/Desktop/Desktop.csproj
@@ -6,6 +6,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>__DESKTOP__</DefineConstants>
+    <Version>3.0.0</Version>
   </PropertyGroup>
 
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />

--- a/src/Bass/iOS/iOS.csproj
+++ b/src/Bass/iOS/iOS.csproj
@@ -6,6 +6,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>__IOS__</DefineConstants>
+    <Version>3.0.0</Version>
   </PropertyGroup>
 
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />


### PR DESCRIPTION
ManagedBass.[AddOns] refers to the ManagedBass version "3.0.0.0", but notation of version in the DLL of the Desktop/iOS version of ManagedBass is "1.0.0.0", which caused the exception.

I'm not very good at English. So I don't know if I'm communicating accurately.
Sorry.