### PR TITLE
Fix `ChannelReferences` attempting JIT compilation on .NET iOS

### DIFF
--- a/src/AddOns/BassAac/BassAac.csproj
+++ b/src/AddOns/BassAac/BassAac.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Aac</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassAc3/BassAc3.csproj
+++ b/src/AddOns/BassAc3/BassAc3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Ac3</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassAdx/BassAdx.csproj
+++ b/src/AddOns/BassAdx/BassAdx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Adx</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassAix/BassAix.csproj
+++ b/src/AddOns/BassAix/BassAix.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Aix</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassAlac/BassAlac.csproj
+++ b/src/AddOns/BassAlac/BassAlac.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Alac</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassApe/BassApe.csproj
+++ b/src/AddOns/BassApe/BassApe.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Ape</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassAsio/BassAsio.csproj
+++ b/src/AddOns/BassAsio/BassAsio.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Asio</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassCd/BassCd.csproj
+++ b/src/AddOns/BassCd/BassCd.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Cd</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassDShow/BassDShow.csproj
+++ b/src/AddOns/BassDShow/BassDShow.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.DShow</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassDsd/BassDsd.csproj
+++ b/src/AddOns/BassDsd/BassDsd.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Dsd</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassEnc/Desktop/Desktop.csproj
+++ b/src/AddOns/BassEnc/Desktop/Desktop.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Enc</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DefineConstants>__DESKTOP__</DefineConstants>

--- a/src/AddOns/BassEnc/ManagedBass.Enc.nuspec
+++ b/src/AddOns/BassEnc/ManagedBass.Enc.nuspec
@@ -20,7 +20,7 @@
              <group targetFramework=".NETFramework4.5">
                 <dependency id="ManagedBass" version="3.0.0" />
             </group>
-            <group targetFramework=".NETStandard1.4">
+            <group targetFramework=".NETStandard2.1">
                 <dependency id="ManagedBass" version="3.0.0" />
             </group>
             <group targetFramework="Xamarin.iOS0.0">
@@ -32,13 +32,13 @@
         <file src="../../../icon.png" target="" />
         <file src="../../../LICENSE.md" target="" />
 
-        <file src="Desktop\bin\Release\netstandard1.4\ManagedBass.Enc.dll" target="lib\net45"/>
-        <file src="Desktop\bin\Release\netstandard1.4\ManagedBass.Enc.xml" target="lib\net45"/>
+        <file src="Desktop\bin\Release\netstandard2.1\ManagedBass.Enc.dll" target="lib\net45"/>
+        <file src="Desktop\bin\Release\netstandard2.1\ManagedBass.Enc.xml" target="lib\net45"/>
 
-        <file src="Portable\bin\Release\netstandard1.4\ManagedBass.Enc.dll" target="lib\netstandard1.4"/>
-        <file src="Portable\bin\Release\netstandard1.4\ManagedBass.Enc.xml" target="lib\netstandard1.4"/>
+        <file src="Portable\bin\Release\netstandard2.1\ManagedBass.Enc.dll" target="lib\netstandard2.1"/>
+        <file src="Portable\bin\Release\netstandard2.1\ManagedBass.Enc.xml" target="lib\netstandard2.1"/>
 
-        <file src="iOS\bin\Release\netstandard1.4\ManagedBass.Enc.dll" target="lib\Xamarin.iOS"/>
-        <file src="iOS\bin\Release\netstandard1.4\ManagedBass.Enc.xml" target="lib\Xamarin.iOS"/>
+        <file src="iOS\bin\Release\netstandard2.1\ManagedBass.Enc.dll" target="lib\Xamarin.iOS"/>
+        <file src="iOS\bin\Release\netstandard2.1\ManagedBass.Enc.xml" target="lib\Xamarin.iOS"/>
     </files>
 </package>

--- a/src/AddOns/BassEnc/Portable/BassEnc.csproj
+++ b/src/AddOns/BassEnc/Portable/BassEnc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Enc</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/AddOns/BassEnc/iOS/iOS.csproj
+++ b/src/AddOns/BassEnc/iOS/iOS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Enc</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DefineConstants>__IOS__</DefineConstants>

--- a/src/AddOns/BassFlac/BassFlac.csproj
+++ b/src/AddOns/BassFlac/BassFlac.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Flac</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassFx/BassFx.csproj
+++ b/src/AddOns/BassFx/BassFx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Fx</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassHls/BassHls.csproj
+++ b/src/AddOns/BassHls/BassHls.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Hls</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassMidi/Desktop/Desktop.csproj
+++ b/src/AddOns/BassMidi/Desktop/Desktop.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Midi</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DefineConstants>__DESKTOP__</DefineConstants>

--- a/src/AddOns/BassMidi/ManagedBass.Midi.nuspec
+++ b/src/AddOns/BassMidi/ManagedBass.Midi.nuspec
@@ -20,7 +20,7 @@
             <group targetFramework=".NETFramework4.5">
                 <dependency id="ManagedBass" version="3.0.0" />
             </group>
-            <group targetFramework=".NETStandard1.4">
+            <group targetFramework=".NETStandard2.1">
                 <dependency id="ManagedBass" version="3.0.0" />
             </group>
             <group targetFramework="Xamarin.iOS0.0">
@@ -32,13 +32,13 @@
         <file src="../../../icon.png" target="" />
         <file src="../../../LICENSE.md" target="" />
 
-        <file src="Desktop\bin\Release\netstandard1.4\ManagedBass.Midi.dll" target="lib\net45"/>
-        <file src="Desktop\bin\Release\netstandard1.4\ManagedBass.Midi.xml" target="lib\net45"/>
+        <file src="Desktop\bin\Release\netstandard2.1\ManagedBass.Midi.dll" target="lib\net45"/>
+        <file src="Desktop\bin\Release\netstandard2.1\ManagedBass.Midi.xml" target="lib\net45"/>
 
-        <file src="Portable\bin\Release\netstandard1.4\ManagedBass.Midi.dll" target="lib\netstandard1.4"/>
-        <file src="Portable\bin\Release\netstandard1.4\ManagedBass.Midi.xml" target="lib\netstandard1.4"/>
+        <file src="Portable\bin\Release\netstandard2.1\ManagedBass.Midi.dll" target="lib\netstandard2.1"/>
+        <file src="Portable\bin\Release\netstandard2.1\ManagedBass.Midi.xml" target="lib\netstandard2.1"/>
 
-        <file src="iOS\bin\Release\netstandard1.4\ManagedBass.Midi.dll" target="lib\Xamarin.iOS"/>
-        <file src="iOS\bin\Release\netstandard1.4\ManagedBass.Midi.xml" target="lib\Xamarin.iOS"/>
+        <file src="iOS\bin\Release\netstandard2.1\ManagedBass.Midi.dll" target="lib\Xamarin.iOS"/>
+        <file src="iOS\bin\Release\netstandard2.1\ManagedBass.Midi.xml" target="lib\Xamarin.iOS"/>
     </files>
 </package>

--- a/src/AddOns/BassMidi/Portable/BassMidi.csproj
+++ b/src/AddOns/BassMidi/Portable/BassMidi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Midi</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/AddOns/BassMidi/iOS/iOS.csproj
+++ b/src/AddOns/BassMidi/iOS/iOS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Midi</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <DefineConstants>__IOS__</DefineConstants>

--- a/src/AddOns/BassMix/BassMix.csproj
+++ b/src/AddOns/BassMix/BassMix.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Mix</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassMpc/BassMpc.csproj
+++ b/src/AddOns/BassMpc/BassMpc.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Mpc</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassOfr/BassOfr.csproj
+++ b/src/AddOns/BassOfr/BassOfr.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Ofr</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassOpus/BassOpus.csproj
+++ b/src/AddOns/BassOpus/BassOpus.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Opus</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassSfx/BassSfx.csproj
+++ b/src/AddOns/BassSfx/BassSfx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Sfx</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassSpx/BassSpx.csproj
+++ b/src/AddOns/BassSpx/BassSpx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Spx</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassTags/BassTags.csproj
+++ b/src/AddOns/BassTags/BassTags.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Tags</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassTta/BassTta.csproj
+++ b/src/AddOns/BassTta/BassTta.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Tta</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassVst/BassVst.csproj
+++ b/src/AddOns/BassVst/BassVst.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Vst</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassWA/BassWA.csproj
+++ b/src/AddOns/BassWA/BassWA.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.WA</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassWaDsp/BassWaDsp.csproj
+++ b/src/AddOns/BassWaDsp/BassWaDsp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.WaDsp</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassWasapi/BassWasapi.csproj
+++ b/src/AddOns/BassWasapi/BassWasapi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Wasapi</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassWinamp/BassWinamp.csproj
+++ b/src/AddOns/BassWinamp/BassWinamp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Winamp</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassWma/BassWma.csproj
+++ b/src/AddOns/BassWma/BassWma.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <AssemblyName>ManagedBass.Wma</AssemblyName>
     <Version>3.0.0</Version>

--- a/src/AddOns/BassWv/BassWv.csproj
+++ b/src/AddOns/BassWv/BassWv.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.Wv</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/AddOns/BassZXTune/BassZXTune.csproj
+++ b/src/AddOns/BassZXTune/BassZXTune.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass.ZXTune</AssemblyName>
     <Version>3.0.0</Version>
     <Authors>MathewSachin</Authors>

--- a/src/Bass/Desktop/Desktop.csproj
+++ b/src/Bass/Desktop/Desktop.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/src/Bass/ManagedBass.nuspec
+++ b/src/Bass/ManagedBass.nuspec
@@ -18,20 +18,20 @@
         <tags>Bass Wasapi Asio Record Audio Music</tags>
         <dependencies>
             <group targetFramework=".NETFramework4.5" />
-            <group targetFramework=".NETStandard1.4" />
+            <group targetFramework=".NETStandard2.1" />
             <group targetFramework="Xamarin.iOS0.0" />
         </dependencies>
     </metadata>
     <files>
         <file src="../../icon.png" target="" />
         <file src="../../LICENSE.md" target="" />
-        <file src="Desktop\bin\Release\netstandard1.4\ManagedBass.dll" target="lib\net45"/>
-        <file src="Desktop\bin\Release\netstandard1.4\ManagedBass.xml" target="lib\net45"/>
+        <file src="Desktop\bin\Release\netstandard2.1\ManagedBass.dll" target="lib\net45"/>
+        <file src="Desktop\bin\Release\netstandard2.1\ManagedBass.xml" target="lib\net45"/>
 
-        <file src="Portable\bin\Release\netstandard1.4\ManagedBass.dll" target="lib\netstandard1.4"/>
-        <file src="Portable\bin\Release\netstandard1.4\ManagedBass.xml" target="lib\netstandard1.4"/>
+        <file src="Portable\bin\Release\netstandard2.1\ManagedBass.dll" target="lib\netstandard2.1"/>
+        <file src="Portable\bin\Release\netstandard2.1\ManagedBass.xml" target="lib\netstandard2.1"/>
 
-        <file src="iOS\bin\Release\netstandard1.4\ManagedBass.dll" target="lib\Xamarin.iOS"/>
-        <file src="iOS\bin\Release\netstandard1.4\ManagedBass.xml" target="lib\Xamarin.iOS"/>
+        <file src="iOS\bin\Release\netstandard2.1\ManagedBass.dll" target="lib\Xamarin.iOS"/>
+        <file src="iOS\bin\Release\netstandard2.1\ManagedBass.xml" target="lib\Xamarin.iOS"/>
     </files>
 </package>

--- a/src/Bass/Portable/Bass.csproj
+++ b/src/Bass/Portable/Bass.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <AssemblyName>ManagedBass</AssemblyName>
     <Version>3.0.0</Version>

--- a/src/Bass/Shared/ChannelReferences.cs
+++ b/src/Bass/Shared/ChannelReferences.cs
@@ -22,7 +22,7 @@ namespace ManagedBass
         {
 #if !__IOS__
             // in .NET iOS, the __IOS__ constant cannot be seen, so rely on RuntimeFeature instead.
-            if (!RuntimeFeature.IsDynamicCodeSupported)
+            if (!RuntimeFeature.IsDynamicCodeCompiled)
                 return;
 
             if (proc == null)
@@ -51,7 +51,7 @@ namespace ManagedBass
         {
 #if !__IOS__
             // in .NET iOS, the __IOS__ constant cannot be seen, so rely on RuntimeFeature instead.
-            if (!RuntimeFeature.IsDynamicCodeSupported)
+            if (!RuntimeFeature.IsDynamicCodeCompiled)
                 return;
 
             var key = Tuple.Create(Handle, SpecialHandle);

--- a/src/Bass/Shared/ChannelReferences.cs
+++ b/src/Bass/Shared/ChannelReferences.cs
@@ -22,7 +22,7 @@ namespace ManagedBass
         {
 #if !__IOS__
             // in .NET iOS, the __IOS__ constant cannot be seen, so rely on RuntimeFeature instead.
-            if (!RuntimeFeature.IsDynamicCodeCompiled)
+            if (!RuntimeFeature.IsDynamicCodeSupported)
                 return;
 
             if (proc == null)
@@ -51,7 +51,7 @@ namespace ManagedBass
         {
 #if !__IOS__
             // in .NET iOS, the __IOS__ constant cannot be seen, so rely on RuntimeFeature instead.
-            if (!RuntimeFeature.IsDynamicCodeCompiled)
+            if (!RuntimeFeature.IsDynamicCodeSupported)
                 return;
 
             var key = Tuple.Create(Handle, SpecialHandle);

--- a/src/Bass/iOS/iOS.csproj
+++ b/src/Bass/iOS/iOS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>ManagedBass</AssemblyName>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>


### PR DESCRIPTION
On .NET iOS, the `__IOS__` constant cannot be seen, causing `ChannelReferences` to assume it's dealing with non-iOS platform and attempts to perform JIT compilation.

I have tried countless ways to get .NET into referencing the iOS-native DLL that contains the above constant to no avail.

So I had to instead replace the constant with a better way of checking whether running in an iOS/AOT-only environment, which is by checking whether the app domain references `Xamarin.iOS`/`Microsoft.iOS`, which is essential for iOS projects.

This unfortunately required me to update all BASS projects to target `netstandard2.1`, but I've went through that and everything works correctly now for me.