### PR TITLE
`BASS_FX_VOLUME` support

### DIFF
--- a/src/AddOns/BassFx/Effects/Objects/VolumeEffect.cs
+++ b/src/AddOns/BassFx/Effects/Objects/VolumeEffect.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ManagedBass.Fx
+{
+    internal class Volume : Effect<VolumeParameters>
+    {
+        /// <summary>
+        /// The new volume level... 0 = silent, 1.0 = normal, above 1.0 = amplification. The default value is 1.
+        /// </summary>
+        public float Target
+        {
+            get => Parameters.fTarget;
+            set
+            {
+                Parameters.fTarget = value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// The current volume level... -1 = leave existing current level when setting parameters. The default value is 1.
+        /// </summary>
+        public float Current
+        {
+            get => Parameters.fCurrent;
+            set
+            {
+                Parameters.fCurrent = value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// The time to take to transition from the current level to the new level, in seconds. The default value is 0.
+        /// </summary>
+        public float Time
+        {
+            get => Parameters.fTime;
+            set
+            {
+                Parameters.fTime = value;
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// The curve to use in the transition... False for linear, true for logarithmic. The default value is false.
+        /// </summary>
+        public bool Curve
+        {
+            get => Convert.ToBoolean(Parameters.lCurve);
+            set
+            {
+                Parameters.lCurve = (uint)(value == true ? 1 : 0);
+                OnPropertyChanged();
+            }
+        }
+
+        /// <summary>
+        /// A <see cref="FXChannelFlags" /> flag to define on which channels to apply the effect. Default: <see cref="FXChannelFlags.All"/>
+        /// </summary>
+        public FXChannelFlags Channels
+        {
+            get => Parameters.lChannel;
+            set
+            {
+                Parameters.lChannel = value;
+
+                OnPropertyChanged();
+            }
+        }
+    }
+}

--- a/src/AddOns/BassFx/Effects/Structures/VolumeParameters.cs
+++ b/src/AddOns/BassFx/Effects/Structures/VolumeParameters.cs
@@ -1,0 +1,38 @@
+﻿using System.Runtime.InteropServices;
+
+namespace ManagedBass.Fx
+{
+    [StructLayout(LayoutKind.Sequential)]
+    internal class VolumeParameters : IEffectParameter
+    {
+        /// <summary>
+        /// The new volume level... 0 = silent, 1.0 = normal, above 1.0 = amplification. The default value is 1. 
+        /// </summary>
+        public float fTarget = 1.0f;
+
+        /// <summary>
+        /// The current volume level... -1 = leave existing current level when setting parameters. The default value is 1. 
+        /// </summary>
+        public float fCurrent = 1.0f;
+
+        /// <summary>
+        /// The time to take to transition from the current level to the new level, in seconds. The default value is 0. 
+        /// </summary>
+        public float fTime = 0;
+
+        /// <summary>
+        /// The curve to use in the transition... 0 = linear, 1 = logarithmic. The default value is 0. 
+        /// </summary>
+        public uint lCurve = 0;
+
+        /// <summary>
+        /// A <see cref="FXChannelFlags" /> flag to define on which channels to apply the effect. Default: <see cref="FXChannelFlags.All"/>
+        /// </summary>
+        public FXChannelFlags lChannel = FXChannelFlags.All;
+
+        /// <summary>
+        /// Gets the <see cref="EffectType"/>.
+        /// </summary>
+        public EffectType FXType => EffectType.Volume;
+    }
+}

--- a/src/Bass/Shared/Bass/Enumerations/EffectType.cs
+++ b/src/Bass/Shared/Bass/Enumerations/EffectType.cs
@@ -52,6 +52,13 @@
         DXReverb,
         #endregion
 
+        #region Bass
+        /// <summary>
+        /// Bass: Volume control (built into Bass itself).
+        /// </summary>
+        Volume,
+        #endregion
+
         #region BassFx
         /// <summary>
         /// BassFx: Channel Volume Ping-Pong (multi channel).
@@ -61,7 +68,7 @@
         /// <summary>
         /// BassFx: Volume control (multi channel).
         /// </summary>
-        Volume = 0x10003,
+        VolumeBfx = 0x10003,
 
         /// <summary>
         /// BassFx: Peaking Equalizer (multi channel).

--- a/src/ManagedBass.sln
+++ b/src/ManagedBass.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29709.97
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33627.172
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Bass", "Bass", "{2F77A940-A236-4FCB-950C-03600F1F4EDC}"
 EndProject
@@ -103,17 +103,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Items", "Items", "{B5C0D018
 	EndProjectSection
 EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		AddOns\BassMidi\Shared\Shared.projitems*{1fb51416-f915-4dbb-9ac2-120333c73ff8}*SharedItemsImports = 13
-		Bass\Shared\Shared.projitems*{2128ef61-f422-439a-beb2-be39bac713ee}*SharedItemsImports = 4
-		AddOns\BassEnc\Shared\Shared.projitems*{3ba4ff0c-458a-44da-b267-3409151598d7}*SharedItemsImports = 4
-		Bass\Shared\Shared.projitems*{78ebb66c-05cb-4a2d-94a7-5eb29c5f02ed}*SharedItemsImports = 4
-		AddOns\BassMidi\Shared\Shared.projitems*{794cfb9c-8bac-48b8-abe6-b1003eae0766}*SharedItemsImports = 4
-		AddOns\BassMidi\Shared\Shared.projitems*{a4d1f1ce-73e9-4f5f-b399-e69d7bf998aa}*SharedItemsImports = 4
-		AddOns\BassEnc\Shared\Shared.projitems*{a885cf43-1f88-4ec7-af35-4c73776b1c42}*SharedItemsImports = 13
-		Bass\Shared\Shared.projitems*{cd4e203e-c152-4914-93f8-59010befcb52}*SharedItemsImports = 13
-		AddOns\BassEnc\Shared\Shared.projitems*{d7a05b65-f427-4d11-a156-5f5459044b22}*SharedItemsImports = 4
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -320,5 +309,19 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2963EB56-09D6-4AFD-863A-6DAF38D4955A}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		AddOns\BassMidi\Shared\Shared.projitems*{1fb51416-f915-4dbb-9ac2-120333c73ff8}*SharedItemsImports = 13
+		Bass\Shared\Shared.projitems*{2128ef61-f422-439a-beb2-be39bac713ee}*SharedItemsImports = 5
+		AddOns\BassEnc\Shared\Shared.projitems*{3ba4ff0c-458a-44da-b267-3409151598d7}*SharedItemsImports = 5
+		Bass\Shared\Shared.projitems*{78ebb66c-05cb-4a2d-94a7-5eb29c5f02ed}*SharedItemsImports = 5
+		AddOns\BassMidi\Shared\Shared.projitems*{794cfb9c-8bac-48b8-abe6-b1003eae0766}*SharedItemsImports = 5
+		AddOns\BassEnc\Shared\Shared.projitems*{8e11e61b-f8db-44a1-b30e-140a46b9d6d4}*SharedItemsImports = 5
+		AddOns\BassMidi\Shared\Shared.projitems*{a4d1f1ce-73e9-4f5f-b399-e69d7bf998aa}*SharedItemsImports = 5
+		AddOns\BassEnc\Shared\Shared.projitems*{a885cf43-1f88-4ec7-af35-4c73776b1c42}*SharedItemsImports = 13
+		AddOns\BassMidi\Shared\Shared.projitems*{b74875b2-2ae0-4665-bc80-33edc955c381}*SharedItemsImports = 5
+		Bass\Shared\Shared.projitems*{cd4e203e-c152-4914-93f8-59010befcb52}*SharedItemsImports = 13
+		AddOns\BassEnc\Shared\Shared.projitems*{d7a05b65-f427-4d11-a156-5f5459044b22}*SharedItemsImports = 5
+		Bass\Shared\Shared.projitems*{e29cfa86-e31d-4694-9cc0-7337502c7746}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This pull request adds support for the [`BASS_FX_VOLUME`](https://www.un4seen.com/doc/#bass/BASS_FX_VOLUME_PARAM.html) effect, which is useful when the developer wants to change the volume of a decoding stream without having to use BASS_FX.

It required renaming the old Volume enum to VolumeBfx, which is a different effect offered by BASS_FX.