### PR TITLE
Fix up BassLoud

### DIFF
--- a/src/AddOns/Bassloud/Bassloud.cs
+++ b/src/AddOns/Bassloud/Bassloud.cs
@@ -8,13 +8,13 @@ namespace ManagedBass.Loud
         const string DllName = "bassloud";
 
         #region Version
-        [DllImport(DllName)]
-        static extern int BASS_Loudness_GetVersion();
+        [DllImport(DllName, EntryPoint = "BASS_Loudness_GetVersion")]
+        static extern int GetVersion();
 
         /// <summary>
         /// Gets the Version of BassFx that is loaded.
         /// </summary>
-        public static Version Version => Extensions.GetVersion(BASS_Loudness_GetVersion());
+        public static Version Version => Extensions.GetVersion(GetVersion());
         #endregion
 
         /// <summary>
@@ -24,20 +24,45 @@ namespace ManagedBass.Loud
         /// <returns>If successful, the loudness measurement's channel handle is returned, else 0 is returned. Use <see cref="Bass.LastError" /> to get the error code.</returns>
         /// <exception cref="Errors.Handle"><paramref name="Handle"/> is not valid.</exception>
         [DllImport(DllName, EntryPoint = "BASS_Loudness_GetChannel")]
-        public static extern int BASS_Loudness_GetChannel(int Handle);
+        public static extern int GetChannel(int Handle);
 
         /// <summary>
         /// Retrieves the level of a loudness measurement.
         /// </summary>
         /// <param name="Handle">The loudness measurement handle.</param>
-        /// <param name="Mode">The measurement type to retrieve. One of the following.</param>
+        /// <param name="Mode">The measurement type to retrieve. One of the following. BassFlags.BassLoudnessCurrent, BassFlags.BassLoudnessIntegrated, BassFlags.BassLoudnessRange, BassFlags.BassLoudnessPeak, BassFlags.BassLoudnessTruePeak.</param>
         /// <param name="Level">Pointer to a variable to receive the measurement level.</param>
         /// <returns>If successful, TRUE is returned, else FALSE is returned. Use <see cref="Bass.LastError"/> to get the error code.</returns>
         /// <exception cref="Errors.Handle"><paramref name="Handle"/> is not valid.</exception>
         /// <exception cref="Errors.Parameter"><paramref name="Mode"/> is not valid. If requesting a duration with BASS_LOUDNESS_CURRENT then it exceeds what has been enabled.</exception>
         /// <exception cref="Errors.NotAvailable">The requested measurement has not been enabled.</exception>
         [DllImport(DllName, EntryPoint = "BASS_Loudness_GetLevel")]
-        public static extern bool BASS_Loudness_GetLevel(int Handle, BassFlags Mode, ref float Level);
+        public static extern bool GetLevel(int Handle, BassFlags Mode, ref float Level);
+
+        /// <summary>
+        /// Retrieves the level of multiple loudness measurements combined.
+        /// </summary>
+        /// <param name="Handles">An array of loudness measurement handles.</param>
+        /// <param name="Count">The number of handles in the array.</param>
+        /// <param name="Mode">The measurement type to retrieve. One of the following. BassFlags.BassLoudnessIntegrated, BassFlags.BassLoudnessRange, BassFlags.BassLoudnessPeak, BassFlags.BassLoudnessTruePeak.</param>
+        /// <param name="Level">Pointer to a variable to receive the measurement level.</param>
+        /// <returns>If successful, TRUE is returned, else FALSE is returned. Use <see cref="Bass.LastError"/> to get the error code.</returns>
+        /// <exception cref="Errors.Handle"><paramref name="Handles"/> is not valid.</exception>
+        /// <exception cref="Errors.Parameter"><paramref name="Mode"/> is not valid. If requesting a duration with BASS_LOUDNESS_CURRENT then it exceeds what has been enabled.</exception>
+        /// <exception cref="Errors.NotAvailable">The requested measurement has not been enabled. It needs to be enabled on all of the provided handles.</exception>
+        [DllImport(DllName, EntryPoint = "BASS_Loudness_GetLevelMulti")]
+        public static extern bool GetLevelMulti(int[] Handles, int Count, BassFlags Mode, ref float Level);
+
+        /// <summary>
+        /// Moves a loudness measurement to another channel or just changes its DSP priority.
+        /// </summary>
+        /// <param name="Handle">The loudness measurement handle.</param>
+        /// <param name="Channel">The channel to move the measurement to... a HSTREAM, HMUSIC, or HRECORD.</param>
+        /// <param name="Priority">The new DSP priority of the measurements.</param>
+        /// <returns>If successful, TRUE is returned, else FALSE is returned. Use <see cref="Bass.LastError"/> to get the error code.</returns>
+        /// <exception cref="Errors.Handle"><paramref name="Handle"/> is not valid.</exception>
+        [DllImport(DllName, EntryPoint = "BASS_Loudness_SetChannel")]
+        public static extern int SetChannel(int Handle, int Channel, int Priority);
 
         /// <summary>
         /// Starts loudness measurement on a channel.
@@ -49,7 +74,7 @@ namespace ManagedBass.Loud
         /// <exception cref="Errors.Handle"><paramref name="Handle"/> is not valid.</exception>
         /// <exception cref="Errors.Memory">There is insufficient memory.</exception>
         [DllImport(DllName, EntryPoint = "BASS_Loudness_Start", CharSet = CharSet.Unicode)]
-        public static extern int BASS_Loudness_Start(int Handle, BassFlags Flags, int Priority);
+        public static extern int Start(int Handle, BassFlags Flags, int Priority);
 
         /// <summary>
         /// Stops a loudness measurement or all loudness measurements on a channel.
@@ -58,6 +83,6 @@ namespace ManagedBass.Loud
         /// <returns>If successful, TRUE is returned, else FALSE is returned. Use <see cref="Bass.LastError"/> to get the error code.</returns>
         /// <exception cref="Errors.Handle"><paramref name="Handle"/> is not valid.</exception>
         [DllImport(DllName, EntryPoint = "BASS_Loudness_Stop")]
-        public static extern bool BASS_Loudness_Stop(int Handle);
+        public static extern bool Stop(int Handle);
     }
 }


### PR DESCRIPTION
cc. @olitee 

This PR cleans up the BassLoud code added in #124:
- Version fetching is fixed
- Function names have been changed to match the style throughout ManagedBass
- `SetChannel` and `GetLevelMulti` bindings have been added
- Some XMLdoc changes

Note: I have not personally tested this code but it's similar enough to the code in the osu! fork's PR which I did test extensively. At the very least I can confidently say that all the bindings except for `SetChannel` and `GetLevelMulti` should work as expected.